### PR TITLE
Prep Zenodo DOI: add .zenodo.json + RELEASE.md

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,30 @@
+{
+  "title": "OSDR Astrobotany — Interactive FAIR & Multi-omics Notebook",
+  "description": "An interactive Jupyter Book providing a standardised FAIR assessment of NASA's Open Science Data Repository (OSDR), plus interactive visualisation, data storytelling, and multi-omic integration (transcriptome, epigenome, microbiome) built live on the OSDR biodata API, with an astrobotany focus. Includes: a live full-repository FAIR scorecard and per-dataset 'improve your FAIRness' report; a scheduled FAIR-over-time tracker; interactive API and dataset explorers; a cross-study Arabidopsis spaceflight-transcriptome reproducibility analysis; an epigenome x transcriptome integration (OSD-217); and a tomato (VEG-05) host-transcriptome x microbiome integration.",
+  "upload_type": "software",
+  "access_right": "open",
+  "license": "CC0-1.0",
+  "creators": [
+    { "name": "Barker, Richard" },
+    { "name": "OSDR team" }
+  ],
+  "keywords": [
+    "OSDR",
+    "GeneLab",
+    "astrobotany",
+    "FAIR",
+    "spaceflight",
+    "Arabidopsis",
+    "tomato",
+    "multi-omics",
+    "microbiome",
+    "Jupyter Book"
+  ],
+  "related_identifiers": [
+    {
+      "relation": "isSupplementTo",
+      "scheme": "url",
+      "identifier": "https://github.com/dr-richard-barker/OSDR_juypter_book.io"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ experiment** ([OSD-120](https://osdr.nasa.gov/bio/repo/data/studies/OSD-120),
 | `CITATION.cff` | ✅ **done** | [`CITATION.cff`](CITATION.cff) (CC0-1.0). |
 | Contributor guide | ✅ **done** | [`CONTRIBUTING.md`](CONTRIBUTING.md). |
 | GitHub Pages enabled | ✅ **confirmed** | Source: GitHub Actions; CI deploys on push to `main`. |
-| Zenodo DOI | 📋 pending | Archive the repo on Zenodo, then add the DOI to `CITATION.cff` + README. |
+| Zenodo DOI | ⚠️ **ready to mint** | `.zenodo.json` + [`RELEASE.md`](RELEASE.md) are in place — turn on the Zenodo↔GitHub hook and cut a `v1.0` release to get the DOI, then drop it into `CITATION.cff` + README. |
 | Quantitative tomato microbiome | ⚠️ recipe + FAIR write-up | OSD-766 is **raw 16S/ITS only**; the [pipeline notebook](chapters/OSDR_tomato_microbiome_pipeline.ipynb) produces real genus abundances in a DADA2/QIIME2 env, and the [tomato chapter](chapters/OSDR_tomato_microbiome.ipynb) §5 FAIR check quantifies the reuse gap. |
 | Submitter "improve your FAIRness" reports | ✅ **done** | [`OSDR_fairness_report.ipynb`](chapters/OSDR_fairness_report.ipynb) — per-dataset report card + prioritised, actionable fixes. |
 | Scheduled full-repo FAIR scoring over time | ✅ **done** | [`OSDR_fair_over_time.ipynb`](chapters/OSDR_fair_over_time.ipynb) + [`_fair_snapshot.py`](chapters/_fair_snapshot.py) + a monthly cron workflow. First snapshot: 640 datasets, FAIR overall **91.0** (Reusable 69.3 = the gap). |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,33 @@
+# Releasing & minting a Zenodo DOI
+
+The book is citable via [`CITATION.cff`](CITATION.cff); this adds a permanent,
+versioned **DOI** by archiving a GitHub release on Zenodo. `.zenodo.json` (repo
+root) supplies the archive metadata automatically — you only do the one-time
+hook-up and the click.
+
+## One-time setup
+1. Sign in to <https://zenodo.org> with your GitHub account.
+2. Go to **Zenodo → Account → GitHub**, and flip the switch **ON** for
+   `dr-richard-barker/OSDR_juypter_book.io`.
+
+## Cut a release (mints the DOI)
+1. On GitHub: **Releases → Draft a new release**.
+2. **Tag**: `v1.0` (create it on `main`). **Title**: `v1.0`.
+3. Publish. Zenodo automatically archives the release and issues a DOI.
+
+## After the DOI exists
+1. Copy the DOI (e.g. `10.5281/zenodo.XXXXXXX`).
+2. Add it to:
+   - [`CITATION.cff`](CITATION.cff) — add under the top level:
+     ```yaml
+     identifiers:
+       - type: doi
+         value: 10.5281/zenodo.XXXXXXX
+     ```
+   - [`README.md`](README.md) — a DOI badge:
+     `[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.XXXXXXX.svg)](https://doi.org/10.5281/zenodo.XXXXXXX)`
+3. Commit. Future releases get a new version DOI under the same "concept" DOI.
+
+> Metadata (title, authors, keywords, licence = CC0-1.0) comes from `.zenodo.json`.
+> If Zenodo rejects the `license` value, set it in the Zenodo deposit UI and it
+> will stick for later versions.


### PR DESCRIPTION
Make the last roadmap item one-click: .zenodo.json supplies archive metadata (title, authors, CC0-1.0, keywords) automatically, and RELEASE.md is a short checklist to enable the Zenodo<->GitHub hook, cut a v1.0 release, and drop the minted DOI into CITATION.cff + README. README loose-end updated to "ready to mint".